### PR TITLE
feat: 优化模型处理逻辑，添加 Pro 前缀支持，更新图标获取方式，更新模型列表

### DIFF
--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -4,45 +4,24 @@ import { getJsonDataFromLocalStorage, setJsonDataToLocalStorage } from "./helper
 import { LOCAL_STORAGE_KEY } from "./types";
 import { checkModelLimit, openAiCompatibleChat } from "./utils";
 
-const modules = import.meta.glob('../assets/img/models/*.*', { eager: true })
+const modules = import.meta.glob('../assets/img/models/*.*', { eager: true });
 
 const _iconCache = {};
 
 let customModels = null;
 let normalizedCustomModel = null;
-export function getCustomModels () {
-  if (!customModels) {
-    customModels = getJsonDataFromLocalStorage(LOCAL_STORAGE_KEY.USER_CUSTOM_MODELS, [])
-    normalizedCustomModel = customModels.map(item => {
-      const resolveFn = (item.paramsMode || item.isOpenAiCompatible) ? getBuildInResolveFn(item) : new Function(`return ${item.resolveFn}`)();
 
-      // 存的是系列模型，需要拆分
-      return item.ids.split(',').map(id => {
-        const icon = item.icon || getModelIcon(id);
-        const [series, ...rest] = id.split('/');
-        return ({ ...item, keywords: item.keywords || keywordsMap[series], ids: void 0, id, series, name: rest.join('/'), resolveFn, icon, isCustom: true })
-      })
-    }).reduce((acc, cur) => [...acc, ...cur], []);
+// 辅助函数：解析模型ID，提取 series、name 和 isPro 标志
+function parseModelId(id) {
+  let isPro = false;
+  let fullName = id;
+  if (id.startsWith('Pro/')) {
+    isPro = true;
+    fullName = id.replace('Pro/', '');
   }
-  return { raw: customModels, normalized: normalizedCustomModel };
-}
-
-
-
-export function setCustomModels (models) {
-  setJsonDataToLocalStorage(LOCAL_STORAGE_KEY.USER_CUSTOM_MODELS, models);
-  getCustomModels();
-}
-
-export function getModelIcon (model) {
-  if (!_iconCache[model]) {
-    const [series] = model.split('/');
-    _iconCache[model] = modules[Object.keys(modules).find(i => i.includes(series))]?.default
-    if (!_iconCache[model]) {
-      _iconCache[model] = 'https://chat.kwok.ink/logo.svg'
-    }
-  }
-  return _iconCache[model];
+  const [series, ...nameParts] = fullName.split('/');
+  const name = nameParts.join('/');
+  return { series, name, isPro };
 }
 
 const keywordsMap = {
@@ -53,91 +32,144 @@ const keywordsMap = {
   'internlm': '书生浦语大模型书生大模型,上海AI实验室,商汤科技,上海人工智能实验室香港中文大学和复旦大学',
   'mistralai': '法国欧洲',
   'deepseek-ai': '私募巨头幻方量化深度求索',
-  '01-ai': '01万物零一万物李开复'
-}
+  '01-ai': '01万物零一万物李开复',
+};
 
+// 修改后的 textModelOf 函数，统一处理 "Pro/" 前缀
 const textModelOf = (id, price, length, needVerify) => {
-  const [series, name] = id.split('/');
-  const icon = getModelIcon(id);
+  const { series, name, isPro } = parseModelId(id);
+  const icon = getModelIcon(id); // 使用原始id获取图标
   const keywords = keywordsMap[series];
-  return { id, name, series, price, length, icon, keywords, needVerify }
+  const displayName = isPro ? `Pro/${name}` : name; // 根据 isPro 添加前缀
+  return { id, name: displayName, series, price, length, icon, keywords, needVerify, isPro };
+};
+
+export function getCustomModels() {
+  if (!customModels) {
+    customModels = getJsonDataFromLocalStorage(LOCAL_STORAGE_KEY.USER_CUSTOM_MODELS, []);
+    normalizedCustomModel = customModels.map(item => {
+      const resolveFn = (item.paramsMode || item.isOpenAiCompatible)
+        ? getBuildInResolveFn(item)
+        : new Function(`return ${item.resolveFn}`)();
+
+      // 拆分多个模型ID，并处理每个ID
+      return item.ids.split(',').map(id => {
+        const { series, name, isPro } = parseModelId(id);
+        const icon = item.icon || getModelIcon(id); // 使用原始id获取图标
+        const displayName = isPro ? `Pro/${name}` : name; // 根据 isPro 添加前缀
+        return ({
+          ...item,
+          keywords: item.keywords || keywordsMap[series],
+          ids: void 0, // 移除原始ids字段
+          id,
+          series,
+          name: displayName,
+          resolveFn,
+          icon,
+          isCustom: true,
+          isPro
+        });
+      });
+    }).reduce((acc, cur) => [...acc, ...cur], []);
+  }
+  return { raw: customModels, normalized: normalizedCustomModel };
 }
 
-export const SILICON_MODELS = [
-  textModelOf("Qwen/Qwen2.5-7B-Instruct", 0, 32),
-  textModelOf("THUDM/glm-4-9b-chat", 0, 32),
-  textModelOf("Qwen/Qwen2.5-Coder-7B-Instruct", -1, 32),
-  textModelOf("Qwen/Qwen2-7B-Instruct", 0, 32),
-  textModelOf("Qwen/Qwen2-1.5B-Instruct", 0, 32),
-  textModelOf("Qwen/Qwen1.5-7B-Chat", 0, 32),
-  textModelOf("THUDM/chatglm3-6b", 0, 32),
-  textModelOf("01-ai/Yi-1.5-9B-Chat-16K", 0, 16),
-  textModelOf("01-ai/Yi-1.5-6B-Chat", 0, 4),
+export function setCustomModels(models) {
+  setJsonDataToLocalStorage(LOCAL_STORAGE_KEY.USER_CUSTOM_MODELS, models);
+  getCustomModels();
+}
+
+// 修改 getModelIcon 函数，确保使用正确的 fullName 获取图标
+export function getModelIcon(model) {
+  if (!_iconCache[model]) {
+    const { series } = parseModelId(model);
+    _iconCache[model] = modules[Object.keys(modules).find(i => i.includes(series))]?.default;
+    if (!_iconCache[model]) {
+      _iconCache[model] = 'https://chat.kwok.ink/logo.svg';
+    }
+  }
+  return _iconCache[model];
+}
+
+const SILICON_MODELS = [
+  // 付费模型
+  textModelOf("Pro/Qwen/Qwen2.5-7B-Instruct", 0.35, 32, false),
+  textModelOf("Pro/Qwen/Qwen2-7B-Instruct", 0.35, 32, false),
+  textModelOf("Pro/Qwen/Qwen2-1.5B-Instruct", 0.35, 32, false),
+  textModelOf("Pro/THUDM/glm-4-9b-chat", 0.35, 32, false),
+  textModelOf("Pro/THUDM/chatglm3-6b", 0.35, 32, false),
+  textModelOf("Pro/01-ai/Yi-1.5-9B-Chat-16K", 0.60, 16, false),
+  textModelOf("Pro/01-ai/Yi-1.5-6B-Chat", 0.35, 4, false),
+  textModelOf("Pro/internlm/internlm2_5-7b-chat", 0.35, 32, false),
+  textModelOf("Pro/google/gemma-2-9b-it", 0.42, 8, false),
+  textModelOf("Pro/meta-llama/Meta-Llama-3.1-8B-Instruct", 0.42, 8, false),
+  textModelOf("Pro/meta-llama/Meta-Llama-3-8B-Instruct", 0.42, 8, false),
+  textModelOf("Qwen/Qwen2.5-72B-Instruct-128K", 4.13, 128, false),
+  textModelOf("Qwen/Qwen2.5-72B-Instruct", 4.13, 32, false),
+  textModelOf("Qwen/Qwen2-72B-Instruct", 4.13, 32, false),
+  textModelOf("Qwen/Qwen2.5-32B-Instruct", 1.26, 32, false),
+  textModelOf("Qwen/Qwen2.5-14B-Instruct", 1.26, 32, false),
+  textModelOf("Qwen/Qwen2.5-Math-72B-Instruct", 4.13, 4, false),
+  textModelOf("Qwen/Qwen2-57B-A14B-Instruct", 1.33, 32, false),
+  textModelOf("deepseek-ai/DeepSeek-V2.5", 1.33, 32, false),
+  textModelOf("deepseek-ai/DeepSeek-Coder-V2-Instruct", 1.33, 32, false),
+  textModelOf("deepseek-ai/DeepSeek-V2-Chat", 1.33, 32, false),
+  textModelOf("TeleAI/TeleChat2", 1.33, 8, true),
+  textModelOf("internlm/internlm2_5-20b-chat", 1.33, 32, false),
+  textModelOf("meta-llama/Meta-Llama-3.1-70B-Instruct", 4.13, 8, false),
+  textModelOf("meta-llama/Meta-Llama-3-70B-Instruct", 4.13, 8, false),
+  textModelOf("meta-llama/Meta-Llama-3.1-405B-Instruct", 21.00, 32, false),
+  textModelOf("google/gemma-2-27b-it", 1.00, 8, false),
+
+  // 免费模型
+  textModelOf("Qwen/Qwen2.5-7B-Instruct", 0, 32, false),
+  textModelOf("Qwen/Qwen2.5-Coder-7B-Instruct", 0, 32, false),
+  textModelOf("internlm/internlm2_5-7b-chat", 0, 32, false),
+  textModelOf("meta-llama/Meta-Llama-3.1-8B-Instruct", 0, 32, true),
+  textModelOf("Qwen/Qwen2-7B-Instruct", 0, 32, false),
+  textModelOf("Qwen/Qwen2-1.5B-Instruct", 0, 32, false),
+  textModelOf("THUDM/glm-4-9b-chat", 0, 128, false),
+  textModelOf("THUDM/chatglm3-6b", 0, 32, false),
+  textModelOf("01-ai/Yi-1.5-9B-Chat-16K", 0, 16, false),
+  textModelOf("01-ai/Yi-1.5-6B-Chat", 0, 4, false),
   textModelOf("google/gemma-2-9b-it", 0, 8, true),
-  textModelOf("internlm/internlm2_5-7b-chat", 0, 32),
   textModelOf("meta-llama/Meta-Llama-3-8B-Instruct", 0, 8, true),
-  textModelOf("meta-llama/Meta-Llama-3.1-8B-Instruct", 0, 8, true),
-  textModelOf("mistralai/Mistral-7B-Instruct-v0.2", 0, 32, true),
-  textModelOf("mattshumer/Reflection-Llama-3.1-70B", 4.13, 8, true),
-  textModelOf("Qwen/Qwen2.5-72B-Instruct", 4.13, 32),
-  textModelOf("Qwen/Qwen2.5-Math-72B-Instruct", 4.13, 32),
-  textModelOf("Qwen/Qwen2.5-32B-Instruct", 1.26, 32),
-  textModelOf("Qwen/Qwen2.5-14B-Instruct", 0.7, 32),
-  textModelOf("Qwen/Qwen2-72B-Instruct", 4.13, 32),
-  textModelOf("Qwen/Qwen2-Math-72B-Instruct", 4.13, 32),
-  textModelOf("Qwen/Qwen2-57B-A14B-Instruct", 1.26, 32),
-  textModelOf("Qwen/Qwen1.5-110B-Chat", 4.13, 32),
-  textModelOf("Qwen/Qwen1.5-32B-Chat", 1.26, 32),
-  textModelOf("Qwen/Qwen1.5-14B-Chat", 0.70, 32),
-  textModelOf("01-ai/Yi-1.5-34B-Chat-16K", 1.26, 16),
-  textModelOf("deepseek-ai/DeepSeek-V2.5", 1.33, 32),
-  textModelOf("deepseek-ai/DeepSeek-Coder-V2-Instruct", 1.33, 32),
-  textModelOf("deepseek-ai/DeepSeek-V2-Chat", 1.33, 32),
-  textModelOf("deepseek-ai/deepseek-llm-67b-chat", 1, 4),
-  textModelOf("internlm/internlm2_5-20b-chat", 32, 1),
-  textModelOf("meta-llama/Meta-Llama-3.1-405B-Instruct", 21, 32, true),
-  textModelOf("meta-llama/Meta-Llama-3.1-70B-Instruct", 4.13, 32, true),
-  textModelOf("meta-llama/Meta-Llama-3-70B-Instruct", 4.13, 32, true),
-  textModelOf("mistralai/Mixtral-8x7B-Instruct-v0.1", 1.26, 32, true),
-  textModelOf("google/gemma-2-27b-it", 1.26, 8, true),
-]
+  textModelOf("Vendor-A/Qwen/Qwen2-72B-Instruct", 0, 32, false)
+];
 
-export const SILICON_MODELS_IDS = SILICON_MODELS.map(i => i.id)
+export const SILICON_MODELS_IDS = SILICON_MODELS.map(i => i.id);
 
-export function getAllTextModels () {
+export function getAllTextModels() {
   return [
     ...getCustomModels().normalized,
     ...SILICON_MODELS
-  ]
+  ];
 }
 
 const customResolveFns = getAllTextModels().filter(item => item.resolveFn).reduce((acc, item) => {
-  acc[item.id] = item.resolveFn
-  return acc
-}, {})
+  acc[item.id] = item.resolveFn;
+  return acc;
+}, {});
 
 /**
- * 
+ * 获取聊天解析器，根据模型ID选择合适的解析函数
  */
-export function getChatResolver (modelId) {
-  if (customResolveFns[modelId]) return customResolveFns[modelId]
+export function getChatResolver(modelId) {
+  if (customResolveFns[modelId]) return customResolveFns[modelId];
   return (...args) => {
     // 硅基模型校验模型限制
-    checkModelLimit(modelId)
-    return openAiCompatibleChat('https://api.siliconflow.cn/v1', getSecretKey(), modelId => modelId, ...args)
-  }
+    checkModelLimit(modelId);
+    return openAiCompatibleChat('https://api.siliconflow.cn/v1', getSecretKey(), modelId => modelId, ...args);
+  };
 }
 
 const imageModelOf = (id, price) => {
-  const isPro = id.startsWith('Pro/');
-  let fullName = id;
-  if (isPro) {
-    fullName = id.replace('Pro/', '')
-  }
-  const [series, name] = fullName.split('/');
-  const icon = getModelIcon(fullName);
-  return { id, name, series, price, icon, isPro }
-}
+  const { series, name, isPro } = parseModelId(id);
+  const icon = getModelIcon(id);
+  const displayName = isPro ? `Pro/${name}` : name;
+  return { id, name: displayName, series, price, icon, isPro };
+};
 
 const IMAGE_MODELS = [
   imageModelOf("black-forest-labs/FLUX.1-dev", 1),
@@ -149,17 +181,17 @@ const IMAGE_MODELS = [
   imageModelOf("stabilityai/sdxl-turbo", -1),
   imageModelOf("ByteDance/SDXL-Lightning", -1),
   imageModelOf('Pro/black-forest-labs/FLUX.1-schnell', 1)
-]
+];
 
 /**
  * 判断体验密钥是否可用
  */
-export function isLimitedModel (modelId) {
-  const IMAGE_LIMITED_MODELS = IMAGE_MODELS.filter(item => item.price > 0).map(item => item.id)
-  const TEXT_LIMITED_MODELS = SILICON_MODELS.filter(item => item.price > 0).map(item => item.id)
-  return IMAGE_LIMITED_MODELS.includes(modelId) || TEXT_LIMITED_MODELS.includes(modelId)
+export function isLimitedModel(modelId) {
+  const IMAGE_LIMITED_MODELS = IMAGE_MODELS.filter(item => item.price > 0).map(item => item.id);
+  const TEXT_LIMITED_MODELS = SILICON_MODELS.filter(item => item.price > 0).map(item => item.id);
+  return IMAGE_LIMITED_MODELS.includes(modelId) || TEXT_LIMITED_MODELS.includes(modelId);
 }
 
-export function getImageModels () {
-  return [...IMAGE_MODELS]
+export function getImageModels() {
+  return [...IMAGE_MODELS];
 }


### PR DESCRIPTION
* 添加了一个新的辅助函数`parseModelId`，用于从模型ID中提取`series`、`name`和`isPro`。(`src/utils/models.js`)
* 更新了`textModelOf`函数，以使用`parseModelId`进行一致的模型ID处理，包括"Pro/"前缀。(`src/utils/models.js`)
* 修改了`getCustomModels`函数，以使用`parseModelId`分割和处理多个模型ID。(`src/utils/models.js`)