### PR TITLE
feat: 增加环境变量，控制试用密钥是否可以使用付费模型，与设定默认激活的模型

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_DEFAULT_SK=sk-qnlqsypvkggctuswwkkpbastbvlixsneemzqmwqhyfijydjo
+VITE_DEFAULT_ACTIVE_MODELS=Qwen/Qwen2.5-7B-Instruct,THUDM/glm-4-9b-chat,01-ai/Yi-1.5-9B-Chat-16K

--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 VITE_DEFAULT_SK=sk-qnlqsypvkggctuswwkkpbastbvlixsneemzqmwqhyfijydjo
+# 是否允许试用key使用付费模型
+VITE_ALLOW_TRIAL_KEY_PAID=false
+# 默认激活的模型
 VITE_DEFAULT_ACTIVE_MODELS=Qwen/Qwen2.5-7B-Instruct,THUDM/glm-4-9b-chat,01-ai/Yi-1.5-9B-Chat-16K

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -3,11 +3,13 @@ import { getAllTextModels } from '../utils/models';
 import { getJsonDataFromLocalStorage, getLocalStorage, setJsonDataToLocalStorage, setLocalStorage } from '../utils/helpers';
 import { LOCAL_STORAGE_KEY } from '../utils/types';
 
-const activeModels = atom(getJsonDataFromLocalStorage(LOCAL_STORAGE_KEY.ACTIVE_MODELS, [
-  'Qwen/Qwen2.5-7B-Instruct',
-  'THUDM/glm-4-9b-chat',
-  '01-ai/Yi-1.5-9B-Chat-16K',
-]))
+const activeModelsFromEnv = import.meta.env.VITE_DEFAULT_ACTIVE_MODELS
+  ? import.meta.env.VITE_DEFAULT_ACTIVE_MODELS.split(',').map(model => model.trim())
+  : []
+
+const activeModels = atom(
+  getJsonDataFromLocalStorage(LOCAL_STORAGE_KEY.ACTIVE_MODELS, activeModelsFromEnv)
+)
 
 export const useActiveModels = () => {
   const [value, setValue] = useAtom(activeModels);
@@ -44,7 +46,7 @@ export const useActiveModels = () => {
 
 const isRowMode = atom(getLocalStorage(LOCAL_STORAGE_KEY.ROW_MODE, 'false') === 'true')
 
-export function useIsRowMode () {
+export function useIsRowMode() {
   const [value, setValue] = useAtom(isRowMode);
   const setIsRows = (isRows) => {
     setLocalStorage(LOCAL_STORAGE_KEY.ROW_MODE, isRows);

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -5,7 +5,7 @@ import { LOCAL_STORAGE_KEY } from '../utils/types';
 
 const activeModelsFromEnv = import.meta.env.VITE_DEFAULT_ACTIVE_MODELS
   ? import.meta.env.VITE_DEFAULT_ACTIVE_MODELS.split(',').map(model => model.trim())
-  : []
+  : ["Qwen/Qwen2.5-7B-Instruct", "THUDM/glm-4-9b-chat", "01-ai/Yi-1.5-9B-Chat-16K"]
 
 const activeModels = atom(
   getJsonDataFromLocalStorage(LOCAL_STORAGE_KEY.ACTIVE_MODELS, activeModelsFromEnv)

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -2,7 +2,7 @@ import { getChatRequestOptions } from "./options/chat-options"
 import { getChatResolver, isLimitedModel } from './models';
 import { fmtBaseUrl } from "./format";
 import { isExperienceSK } from "@src/store/storage";
-export function createOpenAICompatibleRequestOptions (sk, model, messages, options = {}) {
+export function createOpenAICompatibleRequestOptions(sk, model, messages, options = {}) {
   return {
     method: 'POST',
     headers: {
@@ -33,7 +33,7 @@ const defaultModelIdResolver = modelId => {
   return rest.join('/');
 }
 
-export function openAiCompatibleChat (baseUrl, sk, modelIdResolver, model, messages, chatOptions, controller, onChunk, onEnd, onError) {
+export function openAiCompatibleChat(baseUrl, sk, modelIdResolver, model, messages, chatOptions, controller, onChunk, onEnd, onError) {
   const modelId = (modelIdResolver || defaultModelIdResolver)(model) // 取出模型ID
   if (!sk) {
     return onError(new Error('API Key未配置'))
@@ -55,7 +55,7 @@ export function openAiCompatibleChat (baseUrl, sk, modelIdResolver, model, messa
       const decoder = new TextDecoder(); // 创建文本解码器
 
       // 读取流中的数据
-      function read () {
+      function read() {
         reader.read().then(({ done, value }) => {
           if (!controller.current) return;
           if (done) {
@@ -79,7 +79,7 @@ export function openAiCompatibleChat (baseUrl, sk, modelIdResolver, model, messa
     })
 }
 
-export async function streamChat (model, messages, controller, onChunk, onEnd, onError) {
+export async function streamChat(model, messages, controller, onChunk, onEnd, onError) {
   const modelChatOptions = getChatRequestOptions(model)
   try {
     const resolver = getChatResolver(model);
@@ -92,9 +92,9 @@ export async function streamChat (model, messages, controller, onChunk, onEnd, o
 
 export const isBrowserExtension = !!import.meta.env.BROWSER
 
-export function checkModelLimit (modelId) {
+export function checkModelLimit(modelId) {
   if (isExperienceSK()) {
-    if (isLimitedModel(modelId)) {
+    if (isLimitedModel(modelId) && import.meta.env.VITE_ALLOW_TRIAL_KEY_PAID !== 'true') {
       throw new Error('为了长久的提供基础服务，体验密钥暂不支持该模型，请见谅')
     }
   }


### PR DESCRIPTION
环境变量添加：

* `.env`: 添加了 `VITE_ALLOW_TRIAL_KEY_PAID` 来控制试用密钥是否可以使用付费模型，以及 `VITE_DEFAULT_ACTIVE_MODELS` 来指定默认激活的模型。

应用程序更新以使用新的环境变量：

* `src/store/app.js`: 修改了 `activeModels` 初始化，以使用 `VITE_DEFAULT_ACTIVE_MODELS` 环境变量（如果可用），否则回退到默认模型。

* `src/utils/utils.js`: 更新了 `checkModelLimit` 函数，如果试用密钥与付费模型一起使用且 `VITE_ALLOW_TRIAL_KEY_PAID` 未设置为 `true`，则抛出错误。