### PR TITLE
增加docker支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+# 默认的硅基流动 API 密钥
 VITE_DEFAULT_SK=sk-qnlqsypvkggctuswwkkpbastbvlixsneemzqmwqhyfijydjo
 # 是否允许试用key使用付费模型
 VITE_ALLOW_TRIAL_KEY_PAID=false

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,56 @@
+name: build docker image
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Prepare
+        id: prepare
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository }}
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          VERSION="${{ github.ref_name }}"
+          # Strip slash from tag name
+          [[ "${{ github.ref_type }}" == "branch" ]] && VERSION=$(echo $VERSION | sed 's/\//_/')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref_type }}" == "tag" ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo "image=$IMAGE_ID:$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.prepare.outputs.image }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,6 +51,6 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.prepare.outputs.image }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# 使用官方 Node.js 镜像作为基础镜像
+FROM node:18-alpine
+
+# 设置工作目录
+WORKDIR /app
+
+# 安装 pnpm
+RUN npm install -g pnpm
+
+# 复制 package.json 和 pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
+
+# 安装依赖
+RUN pnpm install --frozen-lockfile
+
+# 复制所有源代码
+COPY . .
+
+# 安装 serve 用于服务静态文件
+RUN pnpm add serve
+
+# 复制启动脚本
+COPY start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
+
+# 暴露端口（根据您的前端应用实际使用的端口）
+EXPOSE 3000
+
+# 定义容器启动时执行的命令
+CMD ["sh", "start.sh"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@
 
 当本项目发生版本变更时，会自动打包提交到 Chrome 应用商店和 Edge Addons。并将产生的 zip 文件上传到 [GitHub Releases](https://github.com/KwokKwok/SiloChat/releases)，您也可以直接下载并在浏览器中安装。
 
+## docker部署
+
+``` yaml
+version: '3.8'
+
+services:
+  frontend:
+    image: ghcr.io/KwokKwok/silo:latest
+    ports:
+      - "3000:3000"
+    environment:
+      # 设置默认的硅基流动 API 密钥
+      # - VITE_DEFAULT_SK=
+      # 是否允许试用key使用付费模型
+      - VITE_ALLOW_TRIAL_KEY_PAID=false
+      # 默认激活的模型
+      - VITE_DEFAULT_ACTIVE_MODELS=Qwen/Qwen2.5-7B-Instruct,THUDM/glm-4-9b-chat,01-ai/Yi-1.5-9B-Chat-16K
+```
+
 ## 致谢
 
 1. 感谢 [SiliconCloud](https://siliconflow.cn/zh-cn/siliconcloud)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -43,6 +43,25 @@
 
 When the version of this project changes, it will be automatically packaged and submitted to the Chrome App Store and Edge Addons, and the generated zip file will be uploaded to [GitHub Releases](https://github.com/KwokKwok/SiloChat/releases). You can also download it directly and install it in the browser.
 
+## Docker deployment
+
+``` yaml
+version: '3.8'
+
+services:
+  frontend:
+    image: ghcr.io/KwokKwok/silo:latest
+    ports:
+      - "3000:3000"
+    environment:
+      # Set the default SiliconFlow API key.
+      # - VITE_DEFAULT_SK=
+      # Is it allowed to use a trial key for the paid model?
+      - VITE_ALLOW_TRIAL_KEY_PAID=false
+      # Default activated model
+      - VITE_DEFAULT_ACTIVE_MODELS=Qwen/Qwen2.5-7B-Instruct,THUDM/glm-4-9b-chat,01-ai/Yi-1.5-9B-Chat-16K
+```
+
 ## Acknowledgments
 
 1. Thanks to [SiliconCloud](https://siliconflow.cn/zh-cn/siliconcloud).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  frontend:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# 构建前端应用
+pnpm build
+
+# 使用 serve 运行构建后的静态文件
+npx serve -s dist -l 3000


### PR DESCRIPTION
#7 

> 注意，需合并后Github Actions才能触发自动构建，如需在首次合并请求前审阅或测试docker内容，可将`docker-compse.yml`中的镜像修改为`ghcr.io/cr-zhichen/silo:latest`即可。

启动docker-compse.yml命令如下：

``` yaml
version: '3.8'

services:
  frontend:
    image: ghcr.io/KwokKwok/silo:latest
    ports:
      - "3000:3000"
    environment:
      # 设置默认的硅基流动 API 密钥
      # - VITE_DEFAULT_SK=
      # 是否允许试用key使用付费模型
      - VITE_ALLOW_TRIAL_KEY_PAID=false
      # 默认激活的模型
      - VITE_DEFAULT_ACTIVE_MODELS=Qwen/Qwen2.5-7B-Instruct,THUDM/glm-4-9b-chat,01-ai/Yi-1.5-9B-Chat-16K
```

这次 Pull Request 引入了对项目的 Docker 支持，包括一个 Dockerfile、Docker Compose 配置文件，以及用于构建 Docker 镜像的 GitHub Actions 工作流。此外，还更新了文档，增加了 Docker 部署的说明。

### Docker 支持

* `Dockerfile`：添加了一个 Dockerfile，用于构建项目的 Docker 镜像，包括依赖项的安装和环境的设置。
* `docker-compose.yml`：添加了一个 Docker Compose 配置文件，用于定义在 Docker 容器中运行应用程序的服务和环境。
* `.dockerignore`：将 `node_modules` 添加到了 `.dockerignore` 文件中，以防止不必要的文件被包含在 Docker 镜像中。

### GitHub Actions 工作流

* `.github/workflows/docker-image.yml`：添加了一个 GitHub Actions 工作流，用于自动构建并推送 Docker 镜像到 GitHub Container Registry。

### 文档更新

* `README.md` 和 `README_EN.md`：更新了文档，增加了使用 Docker 部署应用程序的说明。